### PR TITLE
Propagate timestamp from docker-loghose to logzio-nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # VERSION 2.0.1
 
 FROM mhart/alpine-node:7.5.0
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
 MAINTAINER Ran Ramati <ran@logz.io>
 RUN apk add --no-cache bash && rm -rf /var/cache/apk/*
 WORKDIR /usr/src/app

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ function start(opts) {
             else {
               obj.logzio_codec = 'plain';
             }
+            obj['@timestamp'] = (new Date(obj.time)).toISOString();
+            delete obj.time;
             type = 'docker_logs';
         }
         else if (obj.type) {


### PR DESCRIPTION
Propagate timestamp from docker-loghose to logzio-nodejs so that resulting log entry will have correct
timestamp. This is needed to order log entries properly in Kibana.